### PR TITLE
add CMAKE_BUILD_TYPE=Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ git clone https://github.com/atinfinity/livox_ros_driver2.git ws_livox/src/livox
 ```shell
 cd ws_livox
 rosdep install -y -i --from-paths src/livox_ros_driver2
-colcon build --symlink-install
+colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
 ```
 
 ### 2.4 Run Livox ROS Driver 2:


### PR DESCRIPTION
公式側でなぜそうなっているのか不明なのですが。
公式ビルドスクリプト・CmakeLists.txtにそうと ROS2側はデフォルトでDebugビルドになっています。

```console
# default
$ colcon build --symlink-install --event-handlers console_cohesion+ --cmake-args -DCMAKE_VERBOSE_MAKEFILE=ON | grep "Install configuration"
--- stderr: livox_ros_driver2
/usr/include/apr-1.0
apr-1
---
-- Install configuration: ""

# CMAKE_BUILD_TYPE=Release
$ colcon build --symlink-install --event-handlers console_cohesion+ --cmake-args -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE=ON | grep "Install configuration"
--- stderr: livox_ros_driver2
/usr/include/apr-1.0
apr-1
---
-- Install configuration: "Release"
```