### PR TITLE
Changed default frame_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ LiDAR Configurations (such as ip, port, data type... etc.) can be set via a json
       "ip" : "192.168.1.100",  # ip of the LiDAR you want to config
       "pcl_data_type" : 1,
       "pattern_mode" : 0,
+      "frame_id" : "livox_frame",
       "blind_spot_set" : 50,
       "extrinsic_parameter" : {
         "roll": 0.0,
@@ -201,6 +202,7 @@ The parameter attributes in the above json file are described in the following t
 | ip             | String  | Ip of the LiDAR you want to config | 192.168.1.100 |
 | pcl_data_type             | Int | Choose the resolution of the point cloud data to send<br>1 -- Cartesian coordinate data (32 bits)<br>2 -- Cartesian coordinate data (16 bits) <br>3 --Spherical coordinate data| 1           |
 | pattern_mode                | Int     | Space scan pattern<br>0 -- non-repeating scanning pattern mode<br>1 -- repeating scanning pattern mode <br>2 -- repeating scanning pattern mode (low scanning rate) | 0               |
+| frame_id                    | String  | frame_id of LiDAR and IMU                | "livox_frame"   |
 | blind_spot_set (Only for HAP LiDAR)                 | Int     | Set blind spot<br>Range from 50 cm to 200 cm               | 50               |
 | extrinsic_parameter |      | Set extrinsic parameter<br> The data types of "roll" "picth" "yaw" are float <br>  The data types of "x" "y" "z" are int<br>               |
 
@@ -261,6 +263,7 @@ For more infomation about the HAP config, please refer to:
       "ip" : "192.168.1.100",  # ip of the HAP you want to config
       "pcl_data_type" : 1,
       "pattern_mode" : 0,
+      "frame_id" : "livox_hap_frame",
       "blind_spot_set" : 50,
       "extrinsic_parameter" : {
         "roll": 0.0,
@@ -275,6 +278,7 @@ For more infomation about the HAP config, please refer to:
       "ip" : "192.168.1.12",  # ip of the Mid360 you want to config
       "pcl_data_type" : 1,
       "pattern_mode" : 0,
+      "frame_id" : "livox_mid360_frame",
       "extrinsic_parameter" : {
         "roll": 0.0,
         "pitch": 0.0,
@@ -320,6 +324,7 @@ For more infomation about the HAP config, please refer to:
             "ip": "192.168.1.100", # ip of the LiDAR you want to config
             "pcl_data_type": 1,
             "pattern_mode": 0,
+            "frame_id" : "livox_frame",
             "extrinsic_parameter": {
                 "roll": 0.0,
                 "pitch": 0.0,
@@ -363,6 +368,7 @@ For more infomation about the HAP config, please refer to:
             "ip": "192.168.2.100", # ip of the LiDAR you want to config
             "pcl_data_type": 1,
             "pattern_mode": 0,
+            "frame_id" : "livox_frame",
             "extrinsic_parameter": {
                 "roll": 0.0,
                 "pitch": 0.0,

--- a/src/parse_cfg_file/parse_livox_lidar_cfg.cpp
+++ b/src/parse_cfg_file/parse_livox_lidar_cfg.cpp
@@ -93,8 +93,8 @@ bool LivoxLidarConfigParser::ParseUserConfigs(const rapidjson::Document &doc,
       user_config.dual_emit_en = static_cast<uint8_t>(config["dual_emit_en"].GetInt());
     }
     if (!config.HasMember("frame_id")) {
-      user_config.frame_id = "livox_lidar";
-      std::cout << "No frame id was given, set to default of 'livox_lidar'" << std::endl;
+      user_config.frame_id = "livox_frame";
+      std::cout << "No frame id was given, set to default of 'livox_frame'" << std::endl;
     } else {
       user_config.frame_id = static_cast<std::string>(config["frame_id"].GetString());
     }


### PR DESCRIPTION
I changed default frame_id from `livox_lidar` to `livox_frame`.
And, I updated README.